### PR TITLE
Fix: styles for scrolling pages

### DIFF
--- a/src/components/Nft/styled-components.ts
+++ b/src/components/Nft/styled-components.ts
@@ -31,18 +31,18 @@ export const StyledRolesDescription = styled(Text.p)`
 `
 
 const boxStyles = `
-  margin-top: 78px;
-  max-width: 210px;
-  width: 100%;
-  overflow-x: hidden;
-  overflow-y: auto; 
-  position: sticky;
-  top: 24px;
-  box-sizing: border-box;
-  max-height: calc(72vh - (24px * 2));
-  min-height: 500px;
-  border-radius: 5px;
-  padding-right: 14px;
+    margin-top: 78px;
+    max-width: 210px;
+    width: 100%;
+    overflow-x: hidden;
+    overflow-y: auto; 
+    position: sticky;
+    top: 24px;
+    box-sizing: border-box;
+    max-height: calc(100vh - 336px);
+    min-height: 500px;
+    border-radius: 5px;
+    padding-right: 14px;
 `
 
 export const StyledContent = styled(Content)`

--- a/src/components/Token/styled-components.ts
+++ b/src/components/Token/styled-components.ts
@@ -3,16 +3,18 @@ import Content from '@src/components/Content'
 import IndexPages from '../IndexPages'
 
 const boxStyles = `
-  width: 210px;
-  margin-top: 59px;
-  word-wrap: break-word;
-  overflow-x: hidden;
-  overflow-y: auto;
-  position: sticky;
-  top: 24px;
-  contain: paint;
-  box-sizing: border-box;
-  max-height: calc(100vh - (24px * 2));
+    margin-top: 78px;
+    max-width: 210px;
+    width: 100%;
+    overflow-x: hidden;
+    overflow-y: auto; 
+    position: sticky;
+    top: 24px;
+    box-sizing: border-box;
+    max-height: calc(100vh - 336px);
+    min-height: 500px;
+    border-radius: 5px;
+    padding-right: 14px;
 `
 
 export const TokenStyledContent = styled(Content)`

--- a/src/hooks/subgraph/useTokens.ts
+++ b/src/hooks/subgraph/useTokens.ts
@@ -9,7 +9,7 @@ import { TokensQueryFullData } from '@src/shared/types/ipfs'
 import { useStorage } from '@thirdweb-dev/react'
 import { TokensQuery } from '@src/queries'
 
-const PAGE_LIMIT = 50
+const PAGE_LIMIT = 10
 const POLL_INTERVAL = 15000
 
 interface UseTokensConfig {

--- a/src/index.css
+++ b/src/index.css
@@ -99,8 +99,9 @@ section {
   display: block;
 }
 html {
+  overflow-y: scroll;
   line-height: 1;
-  overflow: auto;
+  word-wrap: break-word;
 }
 ol,
 ul {

--- a/src/pages/NftPage.tsx
+++ b/src/pages/NftPage.tsx
@@ -78,6 +78,7 @@ const NftPage = () => {
 
   return (
     <Flex
+      pt={37}
       justifyContent={isNftTab && allLoaded ? 'space-between' : 'center'}
       $gap='20px'
     >


### PR DESCRIPTION
<img width="1627" alt="Screenshot 2024-10-04 at 15 58 24" src="https://github.com/user-attachments/assets/57736124-0d13-4f8f-937d-4113f7021004">
<img width="1604" alt="Screenshot 2024-10-04 at 15 57 51" src="https://github.com/user-attachments/assets/27eed8f7-2d03-4c50-8e83-5676b4e85bea">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced styling for NFT components with improved visual presentation and usability.
	- Increased the number of tokens fetched in a single query from 10 to 50, allowing for more data retrieval at once.
	- Updated the layout of the IndexPages component for better content management.

- **Style**
	- Restructured and organized CSS rules for better readability and consistency across various HTML elements.
	- Improved visual styling of components with updated CSS properties.
	- Adjusted layout spacing in the NftPage component for improved user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->