### PR TITLE
fix: prevent edit icon from disappearing on long page names in EditIn…

### DIFF
--- a/src/components/Edit/EditIndexPageItem.tsx
+++ b/src/components/Edit/EditIndexPageItem.tsx
@@ -83,32 +83,35 @@ const EditIndexPagesItem: React.FC<EditIndexPagesItemProps> = ({
       as={to ? Link : 'div'}
       to={to || ''}
       className={clsx(
-        'flex items-center justify-between w-full box-border rounded transition-colors overflow-hidden px-2 py-1.5 gap-2',
+        'flex justify-between w-full box-border rounded transition-colors overflow-hidden px-2 py-1.5 gap-2',
         active && 'bg-gray-100 text-main-accent',
         hasChild && 'mb-1',
         isGroup
-          ? 'uppercase font-bold text-main-accrent'
+          ? 'uppercase font-bold text-main-accent'
           : 'hover:bg-gray-100 cursor-pointer',
         className
       )}
       onClick={handleClick}
     >
-      {isOn ? (
-        <TextField
-          className='max-w-40'
-          inputProps={{
-            onBlur: handleBlurName,
-            ref: textFieldRef,
-            onKeyDown: handleKeyDown,
-          }}
-          value={name}
-          onChange={handleChangeName}
-          hideError
-        />
-      ) : (
-        name
-      )}
-      <div className='flex items-center gap-2'>
+      <div className='flex-1 break-words min-w-0'>
+        {isOn ? (
+          <TextField
+            className='w-full'
+            inputProps={{
+              onBlur: handleBlurName,
+              ref: textFieldRef,
+              onKeyDown: handleKeyDown,
+            }}
+            value={name}
+            onChange={handleChangeName}
+            hideError
+          />
+        ) : (
+          <span className='block text-sm leading-snug break-words'>{name}</span>
+        )}
+      </div>
+
+      <div className='flex items-center gap-2 flex-shrink-0'>
         {!readonly && editable && (
           <IconButton
             hoverBackground='gray-200'


### PR DESCRIPTION
![Screenshot 2025-05-21 at 13 28 52](https://github.com/user-attachments/assets/f39b36f1-7a6c-4b70-b0d3-85d76eebbc4b)
