### PR TITLE
Revert "feat: change Protofire subgraph to TheGraph"

### DIFF
--- a/src/environment/networks/base.ts
+++ b/src/environment/networks/base.ts
@@ -3,7 +3,7 @@ import { base, Chain } from 'thirdweb/chains'
 import { environment } from '..'
 
 export const baseEnvironment: NetworkConfiguration = Object.freeze({
-  subgraphURL: `https://gateway.thegraph.com/api/subgraphs/id/2z83Z4oed2ynQrbyHVcqn4ARSFfpX5a2MDZbLuEvhsho`,
+  subgraphURL: `https://proxy.base.chain.love/subgraphs/name/base/chainwiki-base`,
   contracts: {
     sx1155NFTFactoryAddress: '0xB4D93753436f5C3b7292990650FE9F70164C98c2',
   },

--- a/src/environment/networks/polygon.ts
+++ b/src/environment/networks/polygon.ts
@@ -3,7 +3,8 @@ import { Chain, polygon } from 'thirdweb/chains'
 
 export const polygonEnvironment: NetworkConfiguration = Object.freeze({
   subgraphURL:
-    'https://gateway.thegraph.com/api/subgraphs/id/CetXtg7uqLw1SPgzAF5fnyifsrk5uYcxw8Vm3bEbtpCy',
+    'https://proxy.polygon.chain.love/subgraphs/name/polygon/chainwiki-polygon',
+  apiKey: 'f9tEp28A9xi7WP8hYoD11jSmeAnkwaAK9755i5NqoUE=',
   contracts: {
     sx1155NFTFactoryAddress: '0x9bfF9401F1807cDC9DcF48E67869Cf555244cE7C',
   },

--- a/src/services/apollo/index.ts
+++ b/src/services/apollo/index.ts
@@ -2,10 +2,11 @@ import { ApolloClient, InMemoryCache } from '@apollo/client'
 import staticConfig from 'src/config'
 import { environment } from 'src/environment'
 
+
 export const commonAppoloClientConfig = {
   cache: new InMemoryCache(),
   headers: {
-    Authorization: `Bearer ${environment.subgraphApiKey}`,
+    Authorization: `Bearer ${staticConfig.isDevMode ? environment.subgraphDevApiKey : environment.subgraphApiKey}`,
   },
 }
 


### PR DESCRIPTION
This reverts commit a95e09b6e91dbb0a5472dfd5cea0b4ed9eb62b8c.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Dev builds now use a separate authentication key for subgraph requests, improving environment-specific behavior.

* Chores
  * Updated Base and Polygon subgraph endpoints to new proxy URLs.
  * Added API key configuration for the Polygon network.

* Refactor
  * Centralized client now selects the Authorization header based on development mode, using a dev key in development and the standard key otherwise for subgraph requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->